### PR TITLE
feat: initial deployment of page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,23 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.0"
+gem "minima", "~> 2.5"
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-sitemap"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# consent
+# Consent Status Website
+
+This Jekyll website displays the current consent status and is designed to be accessed via QR code.
+
+## How it works
+
+- The website shows either "CONSENT GIVEN" or "CONSENT WITHDRAWN" based on the configuration
+- The status is controlled by the `consent_status` value in `_config.yml`
+- The site is automatically deployed to GitHub Pages when changes are pushed to the main branch
+
+## Updating the consent status
+
+To change the consent status:
+
+1. Edit the `_config.yml` file
+2. Change the `consent_status` value to either:
+   - `"given"` - to show consent is given
+   - `"withdrawn"` - to show consent is withdrawn
+3. Optionally update the `last_updated` timestamp
+4. Commit and push the changes
+
+The GitHub Actions workflow will automatically rebuild and deploy the site.
+
+## Example status changes
+
+**To set consent as given:**
+
+```yaml
+consent_status: "given"
+last_updated: "2025-07-27 14:30:00"
+```
+
+**To withdraw consent:**
+
+```yaml
+consent_status: "withdrawn"
+last_updated: "2025-07-27 14:30:00"
+```
+
+## Site features
+
+- Mobile-responsive design optimized for QR code scanning
+- Clear visual indicators (green for given, red for withdrawn)
+- Large, easy-to-read text
+- Automatic deployment via GitHub Actions
+- Timestamp showing when status was last updated
+
+## URL
+
+Once deployed, the site will be available at:
+`https://nathanjnorris.github.io/consent`

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,20 @@
+# Jekyll Configuration
+title: "Consent Status"
+description: "Current consent status display"
+baseurl: ""
+url: "https://nathanjnorris.github.io"
+
+# GitHub Pages settings
+markdown: kramdown
+highlighter: rouge
+plugins:
+  - jekyll-feed
+  - jekyll-sitemap
+
+# Consent Status Configuration
+# Change this value to update the consent status
+# Valid values: "given" or "withdrawn"
+consent_status: "given"
+
+# Optional: Add a timestamp for when status was last changed
+last_updated: "2025-07-27 12:00:00"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site.title }}</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 20px;
+        }
+
+        .status-container {
+            text-align: center;
+            max-width: 500px;
+            width: 100%;
+        }
+
+        .status-display {
+            background: white;
+            border-radius: 20px;
+            padding: 60px 40px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+            margin-bottom: 20px;
+            transition: all 0.3s ease;
+        }
+
+        .status-given {
+            border-left: 8px solid #4CAF50;
+        }
+
+        .status-withdrawn {
+            border-left: 8px solid #f44336;
+        }
+
+        .status-icon {
+            font-size: 80px;
+            margin-bottom: 20px;
+            line-height: 1;
+        }
+
+        .status-given .status-icon {
+            color: #4CAF50;
+        }
+
+        .status-withdrawn .status-icon {
+            color: #f44336;
+        }
+
+        h1 {
+            font-size: 2.5em;
+            margin-bottom: 15px;
+            font-weight: 700;
+            letter-spacing: 2px;
+        }
+
+        .status-given h1 {
+            color: #2E7D32;
+        }
+
+        .status-withdrawn h1 {
+            color: #C62828;
+        }
+
+        .status-message {
+            font-size: 1.2em;
+            color: #666;
+            margin-bottom: 0;
+        }
+
+        .last-updated {
+            background: rgba(255, 255, 255, 0.9);
+            color: #666;
+            padding: 10px 20px;
+            border-radius: 10px;
+            font-size: 0.9em;
+            backdrop-filter: blur(10px);
+        }
+
+        /* Mobile responsiveness */
+        @media (max-width: 600px) {
+            .status-display {
+                padding: 40px 20px;
+            }
+            
+            h1 {
+                font-size: 2em;
+            }
+            
+            .status-icon {
+                font-size: 60px;
+            }
+        }
+
+        /* QR code scanning optimization */
+        @media (max-width: 400px) {
+            body {
+                padding: 10px;
+            }
+            
+            .status-display {
+                padding: 30px 15px;
+            }
+            
+            h1 {
+                font-size: 1.5em;
+                letter-spacing: 1px;
+            }
+            
+            .status-message {
+                font-size: 1em;
+            }
+        }
+    </style>
+</head>
+<body>
+    {{ content }}
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+<div class="status-container">
+  <div class="status-display {% if site.consent_status == 'given' %}status-given{% else %}status-withdrawn{% endif %}">
+    {% if site.consent_status == "given" %}
+      <div class="status-icon">✓</div>
+      <h1>CONSENT GIVEN</h1>
+      <p class="status-message">Consent has been provided</p>
+    {% else %}
+      <div class="status-icon">✗</div>
+      <h1>CONSENT WITHDRAWN</h1>
+      <p class="status-message">Consent has been withdrawn</p>
+    {% endif %}
+  </div>
+  
+  {% if site.last_updated %}
+  <div class="last-updated">
+    Last updated: {{ site.last_updated }}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
This pull request introduces a new Jekyll-based website for displaying consent status with a focus on simplicity, responsiveness, and automation. The changes include setting up the Jekyll environment, configuring the site, designing a responsive layout, and implementing logic to dynamically display the consent status.

### Jekyll Setup and Configuration:
* Added a `Gemfile` to define dependencies for Jekyll, plugins, and platform-specific gems, ensuring compatibility across environments (`Gemfile`).
* Created a `_config.yml` file to configure the Jekyll site, including consent status, plugins, and metadata (`_config.yml`).

### Documentation:
* Updated the `README.md` to document the purpose of the site, how to update the consent status, and its features (`README.md`).

### UI Design and Layout:
* Designed a responsive layout in `_layouts/default.html` with a clean and visually appealing style, optimized for mobile and QR code scanning (`_layouts/default.html`).

### Consent Status Display:
* Implemented the `index.html` file to dynamically display either "CONSENT GIVEN" or "CONSENT WITHDRAWN" based on the `consent_status` value in `_config.yml`, with optional timestamp display (`index.html`).